### PR TITLE
Fix error return array

### DIFF
--- a/db.php
+++ b/db.php
@@ -192,7 +192,7 @@ class SQLSRV_DataBase {
 			 */
 			$error = sqlsrv_errors();
 			$this->error[] = $error;
-			error_log( 'Database failure: ' . print_r($error) );
+			error_log( 'Database failure: ' . print_r($error, true) );
 			return false;
 		}
 		sqlsrv_configure( 'WarningsReturnAsErrors', true );

--- a/db.php
+++ b/db.php
@@ -192,7 +192,7 @@ class SQLSRV_DataBase {
 			 */
 			$error = sqlsrv_errors();
 			$this->error[] = $error;
-			error_log( 'Database failure: ' . $error );
+			error_log( 'Database failure: ' . print_r($error) );
 			return false;
 		}
 		sqlsrv_configure( 'WarningsReturnAsErrors', true );


### PR DESCRIPTION
There is an mistake on error return message: string instead array.
Fixed it.